### PR TITLE
Update npm scripts + bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,23 @@
 # Neuralium Desktop Wallet
 
-##### Version:  MAINNET 1.0.0
+##### Version:  MAINNET 1.0.1
 
 The "pro" Neuralium crypto token desktop user interface
 
 ## Build Instructions
+
 Linux:
 > npm install
-
-> npm run electron:linux
-
-or in testnet:
 
 > npm run electron:linux:mainnet
 
 macOs:
 > npm install
 
-> npm run electron:mac
-
-or in testnet:
-
 > npm run electron:mac:mainnet
 
 Windows:
 > npm install
-
-> npm run electron:windows
-
-or in testnet:
 
 > npm run electron:windows:mainnet
 


### PR DESCRIPTION
The following scripts don't exist:  electron:mac, electron:linux and electron:windows.