### PR TITLE
Fix timestamp in console

### DIFF
--- a/src/app/pages/server/server.component.html
+++ b/src/app/pages/server/server.component.html
@@ -30,7 +30,7 @@
     <div class="console-container">
       <div class="line-element" *ngFor="let message of serverMessages  | slice:sliceStart:sliceEnd">
         <span class="line-sub-element console-elements">
-          [<span class="console-timestamp">{{message.timestamp | FormatTimestamp:'YYYY-MM-DD HH:mm:ss'}}</span> - <span
+          [<span class="console-timestamp">{{message.timestamp | date:'YYYY-MM-dd HH:mm:ss'}}</span> - <span
             class="console-level">{{message.level}}</span>]&nbsp;:&nbsp;<span
             class="console-message">{{message.message}}</span>&nbsp;&#123;
           <span class="console-thread">{{message.GetThread().key}}</span>=<span


### PR DESCRIPTION
Currently the console doesn't display the timestamp of message, this commit fix it. 
Feel free to reject this PR if it is not needed. 
